### PR TITLE
feat/sanity: dashboard 페이지 chart에 필요한 backend api 추가

### DIFF
--- a/src/app/api/member/[team]/route.ts
+++ b/src/app/api/member/[team]/route.ts
@@ -1,0 +1,26 @@
+import { fetchMembersByTeam } from '@/service/member';
+import { NextRequest, NextResponse } from 'next/server';
+type Context = {
+  params: { team: string };
+};
+export async function GET(
+  req: NextRequest,
+  { params }: { params: { team: string } }
+) {
+  const team = params.team;
+
+  if (!team) {
+    return NextResponse.json({ error: 'Team is required' }, { status: 400 });
+  }
+
+  try {
+    const members = await fetchMembersByTeam(team);
+    return NextResponse.json(members, { status: 200 });
+  } catch (error) {
+    console.error('Error fetching members:', error);
+    return NextResponse.json(
+      { error: 'Failed to fetch members' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/member/route.ts
+++ b/src/app/api/member/route.ts
@@ -1,4 +1,4 @@
-import { updateMember } from '@/service/member';
+import { fetchAllMembers, updateMember } from '@/service/member';
 import { NextRequest, NextResponse } from 'next/server';
 
 export async function POST(req: NextRequest) {
@@ -12,5 +12,18 @@ export async function POST(req: NextRequest) {
     }
   } catch (error) {
     return NextResponse.json({ success: false, error });
+  }
+}
+
+export async function GET(req: NextRequest) {
+  try {
+    const members = await fetchAllMembers();
+    return NextResponse.json(members, { status: 200 });
+  } catch (error) {
+    console.error('Error fetching members:', error);
+    return NextResponse.json(
+      { error: 'Failed to fetch members' },
+      { status: 500 }
+    );
   }
 }

--- a/src/app/dashboard/[team]/page.tsx
+++ b/src/app/dashboard/[team]/page.tsx
@@ -2,83 +2,40 @@ import { authOptions } from '@/app/api/auth/authOptions';
 import Chart from '@/components/Chart';
 import { Member } from '@/model/member';
 import { getServerSession } from 'next-auth';
+import { headers } from 'next/headers';
 import { redirect } from 'next/navigation';
 import React from 'react';
 interface Props {
   params: { team: string };
 }
-export const members: Member[] = [
-  { nickname: 'Alice', team: 'Product', score: 25 },
-  { nickname: 'Bob', team: 'Product', score: 18 },
-  { nickname: 'Charlie', team: 'Product', score: 9 },
-  { nickname: 'David', team: 'Product', score: 27 },
-  { nickname: 'Eve', team: 'Product', score: 12 },
-  { nickname: 'Frank', team: 'DevOps', score: 22 },
-  { nickname: 'Grace', team: 'DevOps', score: 19 },
-  { nickname: 'Hannah', team: 'DevOps', score: 15 },
-  { nickname: 'Ivan', team: 'DevOps', score: 8 },
-  { nickname: 'Jack', team: 'Success', score: 23 },
-  { nickname: 'Karen', team: 'Success', score: 17 },
-  { nickname: 'Leo', team: 'Success', score: 14 },
-  { nickname: 'Mia', team: 'Success', score: 9 },
-  { nickname: 'Nina', team: 'Laboratory', score: 26 },
-  { nickname: 'Oscar', team: 'Laboratory', score: 21 },
-  { nickname: 'Paul', team: 'Laboratory', score: 10 },
-  { nickname: 'Quinn', team: 'Laboratory', score: 7 },
-  { nickname: 'Ruth', team: 'Laboratory', score: 5 },
-];
+
+async function fetchMembersByTeam(team: string) {
+  const host = headers().get('host');
+  const protocal = process?.env.NODE_ENV === 'development' ? 'http' : 'https';
+
+  const response = await fetch(`${protocal}://${host}/api/member/${team}`, {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    cache: 'no-store',
+  });
+
+  if (!response.ok) {
+    throw new Error('Failed to fetch members');
+  }
+
+  return await response.json();
+}
+
 export default async function TeamDashboardPage({ params: { team } }: Props) {
   const session = await getServerSession(authOptions);
   const user = session?.user;
   if (!user) redirect('/');
+  const teamResult: Member[] = await fetchMembersByTeam(team);
 
-  const data = [
-    {
-      team: 'product',
-      members: [
-        { nickname: 'Alice', score: 25 },
-        { nickname: 'Bob', score: 18 },
-        { nickname: 'Charlie', score: 9 },
-        { nickname: 'David', score: 27 },
-        { nickname: 'Eve', score: 12 },
-      ],
-    },
-    {
-      team: 'devops',
-      members: [
-        { nickname: 'Frank', score: 22 },
-        { nickname: 'Grace', score: 19 },
-        { nickname: 'Hannah', score: 15 },
-        { nickname: 'Ivan', score: 8 },
-      ],
-    },
-    {
-      team: 'success',
-      members: [
-        { nickname: 'Jack', score: 23 },
-        { nickname: 'Karen', score: 17 },
-        { nickname: 'Leo', score: 14 },
-        { nickname: 'Mia', score: 9 },
-      ],
-    },
-    {
-      team: 'laboratory',
-      members: [
-        { nickname: 'Nina', score: 26 },
-        { nickname: 'Oscar', score: 21 },
-        { nickname: 'Paul', score: 10 },
-        { nickname: 'Quinn', score: 7 },
-        { nickname: 'Ruth', score: 5 },
-      ],
-    },
-  ];
-  const getTeamData = (teamName: string) => {
-    return data.find((item) => item.team === teamName);
-  };
-  const teamData = getTeamData(team);
-  if (!teamData) return;
-  const teamName = teamData?.members.map((member) => member.nickname);
-  const teamScore = teamData?.members.map((member) => member.score);
+  const teamName = teamResult.map((member) => member.nickname);
+  const teamScore = teamResult.map((member) => member.score);
   const databases = [
     {
       label: '총 점수',

--- a/src/app/result/page.tsx
+++ b/src/app/result/page.tsx
@@ -7,6 +7,7 @@ export type ResultType = {
   normal: { content: string };
   consideration: { content: string };
 };
+
 export default function ResultPage() {
   const result: ResultType = {
     excellent: {
@@ -19,40 +20,11 @@ export default function ResultPage() {
       content: '고려해볼만한 지원자입니다 🤔',
     },
   };
-  const teamResult = [
-    {
-      nickname: 'Levi',
-      score: 29,
-    },
-    {
-      nickname: 'Noah',
-      score: 18,
-    },
-    {
-      nickname: 'Jeff',
-      score: 9,
-    },
-    {
-      nickname: 'Jeff',
-      score: 9,
-    },
-    {
-      nickname: 'Jeff',
-      score: 9,
-    },
-    {
-      nickname: 'Jeff',
-      score: 9,
-    },
-    {
-      nickname: 'Jeff',
-      score: 9,
-    },
-  ];
+
   return (
     <div className='main-theme h-dvh overflow-y-auto'>
       <Header />
-      <ResultForm result={result} teamResult={teamResult} />
+      <ResultForm result={result} />
     </div>
   );
 }

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -16,7 +16,7 @@ export default function NavBar({ teams }: Props) {
 
       {teams &&
         teams.map((team, i) => (
-          <ActiveLink key={i} href={`/dashboard/${team.toLowerCase()}`}>
+          <ActiveLink key={i} href={`/dashboard/${team}`}>
             {team}
           </ActiveLink>
         ))}

--- a/src/components/RatingQuestion.tsx
+++ b/src/components/RatingQuestion.tsx
@@ -56,7 +56,6 @@ export default function RatingQuestion({
         }),
       });
       if (response.ok) {
-        console.log('res : ', response);
         router.push('/result');
       }
     } else {

--- a/src/components/ResultForm.tsx
+++ b/src/components/ResultForm.tsx
@@ -1,27 +1,45 @@
 'use client';
 import { useStore } from '@/store';
 import { redirect, useRouter } from 'next/navigation';
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import Button from './Button';
 import { ResultType } from '@/app/result/page';
 import Chart from './Chart';
 import { Member } from '@/model/member';
 import { calculateTotalData, description } from '@/util/result';
-
 interface ResultProps {
   result: ResultType;
-  teamResult: Pick<Member, 'nickname' | 'score'>[];
 }
 
-export default function ResultForm({ result, teamResult }: ResultProps) {
+export default function ResultForm({ result }: ResultProps) {
   const router = useRouter();
 
   const nickname = useStore((state) => state.nickname);
   const team = useStore((state) => state.team);
   const total = useStore((state) => state.total);
+  const [members, setMembers] = useState<Member[]>([]);
+
+  useEffect(() => {
+    const fetchMembers = async () => {
+      try {
+        const response = await fetch(`/api/member/${team}`);
+        if (!response.ok) {
+          throw new Error('Failed to fetch members');
+        }
+        const data: Member[] = await response.json();
+        setMembers(data);
+      } catch (error) {
+        console.error('Error fetching members:', error);
+      }
+    };
+
+    if (team) {
+      fetchMembers();
+    }
+  }, [team]);
 
   if (!total) redirect('/');
-  const totalData = calculateTotalData(teamResult);
+  const totalData = calculateTotalData(members);
 
   const handleGoHome = () => {
     router.push('/');

--- a/src/service/member.ts
+++ b/src/service/member.ts
@@ -57,3 +57,41 @@ export async function updateMember(member: Member) {
     throw new Error('Failed to add or update member');
   }
 }
+
+export async function fetchMembersByTeam(team: string) {
+  try {
+    const members = await client.fetch(
+      `
+       *[_type == "member" && team->name == $team]{
+        team,
+        nickname,
+        score
+      }
+      `,
+      { team }
+    );
+
+    return members;
+  } catch (error) {
+    console.error('Error fetching members', error);
+    throw new Error('Failed to fetch members');
+  }
+}
+
+export async function fetchAllMembers(): Promise<Member[]> {
+  try {
+    const members = await client.fetch(
+      `
+        *[_type == "member"] | order(team->name asc) {
+        "team": team->name,
+        nickname,
+        score
+      }
+      `
+    );
+    return members;
+  } catch (error) {
+    console.error('Error fetching members', error);
+    throw new Error('Failed to fetch members');
+  }
+}


### PR DESCRIPTION
- 설문조사 결과 페이지와 대시보드 팀별 페이지에 있는 차트에 필요한 fetchMembersByTeam api 개발
- 대시보드 첫페이지에 팀별 총합, 평균, 표준편차에 필요한 모든 멤버 목록 리턴하는 fetchAllMembers api 개발