### PR TITLE
refactor/react-query: getMembersByTeam api를 react-query를 사용하여 Server side에서 Client sider로 

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
+    "prod": "next build && next start",
     "lint": "next lint"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
   },
   "dependencies": {
     "@sanity/client": "^6.21.0",
+    "@tanstack/react-query": "^5.51.5",
+    "@tanstack/react-query-devtools": "^5.51.5",
     "chart.js": "^4.4.3",
     "next": "14.2.4",
     "next-auth": "^4.24.7",

--- a/src/app/api/member/[team]/route.ts
+++ b/src/app/api/member/[team]/route.ts
@@ -1,6 +1,8 @@
 import { fetchMembersByTeam } from '@/service/member';
 import { NextRequest, NextResponse } from 'next/server';
 
+export const fetchCache = 'force-no-store';
+
 export async function GET(
   req: NextRequest,
   { params }: { params: { team: string } }

--- a/src/app/api/queryClient.ts
+++ b/src/app/api/queryClient.ts
@@ -1,0 +1,14 @@
+import { QueryClient } from '@tanstack/react-query';
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: false,
+    },
+    mutations: {
+      retry: false,
+    },
+  },
+});
+
+export default queryClient;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import { Open_Sans } from 'next/font/google';
 import './globals.css';
+import QueryProvider from '@/components/QueryProvider';
 
 const openSans = Open_Sans({ subsets: ['latin'] });
 
@@ -19,7 +20,9 @@ export default function RootLayout({
 }>) {
   return (
     <html lang='en' className={openSans.className}>
-      <body>{children}</body>
+      <QueryProvider>
+        <body>{children}</body>
+      </QueryProvider>
     </html>
   );
 }

--- a/src/app/result/page.tsx
+++ b/src/app/result/page.tsx
@@ -1,7 +1,5 @@
 import Header from '@/components/Header';
 import ResultForm from '@/components/ResultForm';
-import { Member } from '@/model/member';
-import { fetchMembersByTeam } from '@/service/member';
 import React from 'react';
 
 export const metadata = {
@@ -14,13 +12,7 @@ export type ResultType = {
   consideration: { content: string };
 };
 
-export default async function ResultPage(props: any) {
-  let team = '';
-  let members: Member[] = [];
-  if (props.searchParams.team) {
-    team = props.searchParams.team;
-    members = await fetchMembersByTeam(team);
-  }
+export default async function ResultPage() {
   const result: ResultType = {
     excellent: {
       content: '매우 적합한 지원자입니다! 😆',
@@ -36,7 +28,7 @@ export default async function ResultPage(props: any) {
   return (
     <div className='main-theme h-dvh overflow-y-auto'>
       <Header />
-      <ResultForm result={result} members={members} />
+      <ResultForm result={result} />
     </div>
   );
 }

--- a/src/components/MultipleChoices.tsx
+++ b/src/components/MultipleChoices.tsx
@@ -3,19 +3,13 @@ import { StepProps } from './SingleChoice';
 import { useStore } from '@/store';
 import ButtonForm from './ButtonForm';
 
-export default function MultipleChoices({
-  step,
-  setStep,
-  survey,
-  sumTotal,
-}: StepProps) {
+export default function MultipleChoices({ step, setStep, survey }: StepProps) {
   const onToast = useStore((state) => state.onToast);
   const selectedIndex = useStore((state) => state.selectedIndex);
   const setSelectedIndex = useStore((state) => state.setSelectedIndex);
   const [selectedAnswer, setSelectedAnswer] = useState<number[]>(
     selectedIndex[step].index as number[]
   );
-
   const handleNext = () => {
     if (selectedAnswer.length === 2) {
       setStep(step + 1);

--- a/src/components/QueryProvider.tsx
+++ b/src/components/QueryProvider.tsx
@@ -1,0 +1,17 @@
+'use client';
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
+import React from 'react';
+import { QueryClientProvider } from '@tanstack/react-query';
+import queryClient from '@/app/api/queryClient';
+export default function QueryProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <QueryClientProvider client={queryClient}>
+      {children}
+      <ReactQueryDevtools />
+    </QueryClientProvider>
+  );
+}

--- a/src/components/ResultForm.tsx
+++ b/src/components/ResultForm.tsx
@@ -5,21 +5,23 @@ import React from 'react';
 import Button from './Button';
 import { ResultType } from '@/app/result/page';
 import Chart from './Chart';
-import { Member } from '@/model/member';
 import { calculateTotalData, description } from '@/util/result';
+import { useMember } from '@/hook/useMember';
 interface ResultProps {
   result: ResultType;
-  members: Member[];
 }
 
-export default function ResultForm({ result, members }: ResultProps) {
+export default function ResultForm({ result }: ResultProps) {
   const router = useRouter();
+
+  const { members } = useMember();
 
   const nickname = useStore((state) => state.nickname);
   const team = useStore((state) => state.team);
   const total = useStore((state) => state.total);
 
   if (!total) redirect('/');
+
   const totalData = calculateTotalData(members);
 
   const handleGoHome = () => {

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,0 +1,1 @@
+export * from '@/constants/keys';

--- a/src/constants/keys.ts
+++ b/src/constants/keys.ts
@@ -1,0 +1,5 @@
+const queryKeys = {
+  MEMBER: 'member',
+};
+
+export { queryKeys };

--- a/src/hook/useMember.ts
+++ b/src/hook/useMember.ts
@@ -1,0 +1,20 @@
+import { queryKeys } from '@/constants';
+import { useStore } from '@/store';
+import { getMembersByTeam } from '@/util/member';
+import { useQuery } from '@tanstack/react-query';
+
+const useGetMembersByTeam = () => {
+  const team = useStore((state) => state.team);
+  const { data, isSuccess } = useQuery({
+    queryKey: [queryKeys.MEMBER, team],
+    queryFn: () => getMembersByTeam(team),
+    staleTime: 0,
+  });
+
+  return isSuccess ? data : [];
+};
+
+export const useMember = () => {
+  const members = useGetMembersByTeam();
+  return { members };
+};

--- a/src/service/member.ts
+++ b/src/service/member.ts
@@ -1,10 +1,8 @@
 import { Member } from '@/model/member';
 import { client } from './sanity';
-import { headers } from 'next/headers';
 
-export async function updateMember(member: Member) {
+async function updateMember(member: Member) {
   try {
-    // team 이름을 기반으로 team 문서의 _id 조회
     const team = await client.fetch(
       `
       *[_type == "team" && name == $name]{
@@ -20,7 +18,6 @@ export async function updateMember(member: Member) {
 
     const teamId = team._id;
 
-    // 기존 멤버 조회
     const existingMembers = await client.fetch(
       `
       *[_type == "member" && nickname == $nickname && team._ref == $teamId]{
@@ -40,7 +37,6 @@ export async function updateMember(member: Member) {
 
       return result;
     } else {
-      // 기존 멤버가 존재하지 않으면 새로운 멤버 추가
       const result = await client.create({
         _type: 'member',
         nickname: member.nickname,
@@ -59,7 +55,7 @@ export async function updateMember(member: Member) {
   }
 }
 
-export async function fetchMembersByTeam(team: string): Promise<Member[]> {
+async function fetchMembersByTeam(team: string): Promise<Member[]> {
   try {
     const members = await client.fetch(
       `
@@ -71,7 +67,6 @@ export async function fetchMembersByTeam(team: string): Promise<Member[]> {
       `,
       { team }
     );
-
     return members;
   } catch (error) {
     console.error('Error fetching members', error);
@@ -79,7 +74,7 @@ export async function fetchMembersByTeam(team: string): Promise<Member[]> {
   }
 }
 
-export async function fetchAllMembers(): Promise<Member[]> {
+async function fetchAllMembers(): Promise<Member[]> {
   try {
     const members = await client.fetch(
       `
@@ -97,41 +92,4 @@ export async function fetchAllMembers(): Promise<Member[]> {
   }
 }
 
-export async function getMembersByTeam(team: string) {
-  const response = await fetch(
-    `${process.env.NEXT_PUBLIC_BASE_PATH}/api/member/${team}`,
-    {
-      method: 'GET',
-      headers: {
-        'Content-Type': 'application/json',
-        'Cache-Control': 'no-store',
-      },
-      cache: 'no-store',
-    }
-  );
-
-  if (!response.ok) {
-    throw new Error('Failed to fetch members');
-  }
-
-  return await response.json();
-}
-
-export async function getAllMembers() {
-  const response = await fetch(
-    `${process.env.NEXT_PUBLIC_BASE_PATH}/api/member`,
-    {
-      method: 'GET',
-      headers: {
-        'Content-Type': 'application/json',
-        'Cache-Control': 'no-store',
-      },
-      cache: 'no-store',
-    }
-  );
-  if (!response.ok) {
-    throw new Error('Failed to fetch members');
-  }
-
-  return await response.json();
-}
+export { updateMember, fetchMembersByTeam, fetchAllMembers };

--- a/src/util/member.ts
+++ b/src/util/member.ts
@@ -1,0 +1,36 @@
+async function getMembersByTeam(team: string) {
+  const response = await fetch(
+    `${process.env.NEXT_PUBLIC_BASE_PATH}/api/member/${team}`,
+    {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    }
+  );
+
+  if (!response.ok) {
+    throw new Error('Failed to fetch members');
+  }
+
+  return await response.json();
+}
+
+async function getAllMembers() {
+  const response = await fetch(
+    `${process.env.NEXT_PUBLIC_BASE_PATH}/api/member`,
+    {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    }
+  );
+  if (!response.ok) {
+    throw new Error('Failed to fetch members');
+  }
+
+  return await response.json();
+}
+
+export { getMembersByTeam, getAllMembers };

--- a/yarn.lock
+++ b/yarn.lock
@@ -239,6 +239,30 @@
     "@swc/counter" "^0.1.3"
     tslib "^2.4.0"
 
+"@tanstack/query-core@5.51.5":
+  version "5.51.5"
+  resolved "https://registry.yarnpkg.com/@tanstack/query-core/-/query-core-5.51.5.tgz#80adac6c8ad8e125d1f6fc99b24bc97ad27f3bd4"
+  integrity sha512-qovOto6hFet2zA4Pf3cDO+qkOqskO6xP39PlKnr6YKPtjRsePWyZnTaMf59+VnlOLY8gpku1I4WPC4dqBXo4FQ==
+
+"@tanstack/query-devtools@5.51.1":
+  version "5.51.1"
+  resolved "https://registry.yarnpkg.com/@tanstack/query-devtools/-/query-devtools-5.51.1.tgz#80fb2b16cc11896b808d17b23487c43db38d22a8"
+  integrity sha512-rehG0WmL3EXER6MAI2uHQia/n0b5c3ZROohpYm7u3G7yg4q+HsfQy6nuAo6uy40NzHUe3FmnfWCZQ0Vb/3lE6g==
+
+"@tanstack/react-query-devtools@^5.51.5":
+  version "5.51.5"
+  resolved "https://registry.yarnpkg.com/@tanstack/react-query-devtools/-/react-query-devtools-5.51.5.tgz#b9a07c403eb1b64c2e187045cad4128893f0efad"
+  integrity sha512-Gu2jSgFuCGnD8tGCJpwpkmrQ3F2j13dgxjKRY+yGN7aN5W7Wxo9jEUctlKotGvXDn/iFE/uscTRsE1Au7wBWPQ==
+  dependencies:
+    "@tanstack/query-devtools" "5.51.1"
+
+"@tanstack/react-query@^5.51.5":
+  version "5.51.5"
+  resolved "https://registry.yarnpkg.com/@tanstack/react-query/-/react-query-5.51.5.tgz#f4439ff91717869fef9e68eaf7075cb20352c8ca"
+  integrity sha512-jaYYPGF55HT3DSV2NxFHa7zGRUm6LiRENw1rspkzqNiOU93umP5YCdE/l4S61/ZdLnjzwYIM4FU96EQt+imq5Q==
+  dependencies:
+    "@tanstack/query-core" "5.51.5"
+
 "@types/event-source-polyfill@1.0.5":
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/@types/event-source-polyfill/-/event-source-polyfill-1.0.5.tgz#7223387b99ff519b0fed6278961c84315ffc14b7"


### PR DESCRIPTION
## 문제
/result 페이지에서 팀별 멤버 점수 정보를 가져오는  getMembersByTeam api를 SSR로 구현하였는데 
fetch api에 cache 설정을 'no-store'로 설정하여 SSR을 예상했지만 
실시간 데이터를 배포상태에서 반영하지 못하는 문제 발생

## 시행착오
api 가 있는 route.ts에 따로 옵션 추가 하였지만, 간혈적으로 실시간 데이터를 Fetching하는 문제 발생
```
export const dynamic = 'force-dynamic';
export const fetchCache = 'force-no-store';
```

## 결과
SSR -> CSR로 fetching 하도록 수정

- React-Query를 사용하기위해 React-Query와 React-Query-Devtools 의존성 설치
- member 관련 api를 utils 폴더에서 관리
- getMembersByTeam api를 react-query를 사용하여 SSR에서 CSR로 수정
- fetchCache 옵션으로 응답과 요청을 캐시하지 않도록 수정
